### PR TITLE
FrameFix

### DIFF
--- a/src/net/launcher/components/Frame.java
+++ b/src/net/launcher/components/Frame.java
@@ -35,7 +35,6 @@ import net.launcher.utils.ThemeUtils;
 import net.launcher.utils.ThreadUtils;
 import static net.launcher.utils.BaseUtils.*;
 
-import com.sun.awt.AWTUtilities;
 
 public class Frame extends JFrame implements ActionListener, FocusListener {
 	boolean b1 = false;
@@ -127,7 +126,7 @@ public class Frame extends JFrame implements ActionListener, FocusListener {
 		setLayout(new BorderLayout());
 		setUndecorated(Settings.customframe && BaseUtils.getPlatform() != 0);
 		if (isUndecorated())
-			AWTUtilities.setWindowOpaque(this, false);
+			this.setBackground(new Color(0,0,0,0));
 		setResizable(false);
 
 		for (int i = 0; i < links.length; i++) {


### PR DESCRIPTION
Как мы знаем, уже сейчас минимальная версия JVM - 7чка, учитывая код
Следовательно, нам незачем пользоваться проприетарной херней, которая, к тому же некорректно работает на некоторых линуксах!
Заменил на встроенную функцию Java 7 и выше